### PR TITLE
Tests are failing

### DIFF
--- a/Source/GPHChannel.swift
+++ b/Source/GPHChannel.swift
@@ -152,7 +152,7 @@ extension GPHChannel: GPHMappable {
         obj.jsonRepresentation = jsonData
         
         if let imageData = jsonData["featured_gif"] as? GPHJSONObject {
-            obj.featuredGif = try GPHMedia.mapData(nil, data: imageData, request: requestType)
+            obj.featuredGif = try GPHMedia.mapData(nil, data: imageData, request: requestType, media: mediaType)
         }
         
         // Handle User Data

--- a/Source/GPHChannelResponse.swift
+++ b/Source/GPHChannelResponse.swift
@@ -68,7 +68,7 @@ extension GPHChannelResponse: GPHMappable {
         }
         
         let meta = try GPHMeta.mapData(nil, data: metaData, request: requestType, media: mediaType, rendition: renditionType)
-        let channel = try GPHChannel.mapData(nil, data: channelData, request: requestType)
+        let channel = try GPHChannel.mapData(nil, data: channelData, request: requestType, media: mediaType)
         
         return GPHChannelResponse(meta, data: channel)
     }

--- a/Tests/GiphyCoreSDK+XCTest.swift
+++ b/Tests/GiphyCoreSDK+XCTest.swift
@@ -479,7 +479,7 @@ extension XCTestCase {
                        "Gif frames won't match")
         
         XCTAssertEqual(obj.webPUrl,
-                       obj.jsonRepresentation!["webp_url"] as? String,
+                       obj.jsonRepresentation!["webp"] as? String,
                        "WebP url won't match")
         
         XCTAssertEqual(obj.webPSize,
@@ -487,7 +487,7 @@ extension XCTestCase {
                        "WebP size won't match")
         
         XCTAssertEqual(obj.mp4Url,
-                       obj.jsonRepresentation!["mp4_url"] as? String,
+                       obj.jsonRepresentation!["mp4"] as? String,
                        "Mp4 url won't match")
         
         XCTAssertEqual(obj.mp4Size,


### PR DESCRIPTION
The json returned now contains ```webp``` instead of ```webp_url```, and ```mp4``` instead of ```mp4_url```.
Also added the ```mediaType``` on channels that was failing on stickers case.