### PR TITLE
Expose some GPHImage properties so they can be accessed by Obj-C

### DIFF
--- a/Source/GPHImage.swift
+++ b/Source/GPHImage.swift
@@ -39,7 +39,7 @@ import Foundation
     public fileprivate(set) var frames: Int?
     
     /// Gif file size in bytes.
-    public fileprivate(set) var gifSize: Int?
+    public fileprivate(set) var gifSize: Int = 0
     
     /// URL of the WebP file.
     public fileprivate(set) var webPUrl: String?
@@ -84,7 +84,7 @@ import Foundation
                   
         self.gifUrl = aDecoder.decodeObject(forKey: "gifUrl") as? String
         self.stillGifUrl = aDecoder.decodeObject(forKey: "stillGifUrl") as? String
-        self.gifSize = aDecoder.decodeObject(forKey: "gifSize") as? Int
+        self.gifSize = aDecoder.decodeObject(forKey: "gifSize") as? Int ?? 0
         self.width = aDecoder.decodeObject(forKey: "width") as? Int ?? 0
         self.height = aDecoder.decodeObject(forKey: "height") as? Int ?? 0
         self.frames = aDecoder.decodeObject(forKey: "frames") as? Int
@@ -161,8 +161,8 @@ extension GPHImage: GPHMappable {
         let obj = GPHImage(mediaId, rendition: renditionType)
         
         obj.gifUrl = jsonData["url"] as? String
-        obj.stillGifUrl = jsonData["still_url"]  as? String
-        obj.gifSize = parseInt(jsonData["size"] as? String)
+        obj.stillGifUrl = jsonData["still_url"] as? String
+        obj.gifSize = parseInt(jsonData["size"] as? String) ?? 0
         obj.width = parseInt(jsonData["width"] as? String) ?? 0
         obj.height = parseInt(jsonData["height"] as? String) ?? 0
         obj.frames = parseInt(jsonData["frames"] as? String)

--- a/Source/GPHImage.swift
+++ b/Source/GPHImage.swift
@@ -30,10 +30,10 @@ import Foundation
     public fileprivate(set) var stillGifUrl: String?
     
     /// Width.
-    public fileprivate(set) var width: Int?
+    public fileprivate(set) var width: Int = 0
     
     /// Height.
-    public fileprivate(set) var height: Int?
+    public fileprivate(set) var height: Int = 0
 
     /// # of Frames.
     public fileprivate(set) var frames: Int?
@@ -85,8 +85,8 @@ import Foundation
         self.gifUrl = aDecoder.decodeObject(forKey: "gifUrl") as? String
         self.stillGifUrl = aDecoder.decodeObject(forKey: "stillGifUrl") as? String
         self.gifSize = aDecoder.decodeObject(forKey: "gifSize") as? Int
-        self.width = aDecoder.decodeObject(forKey: "width") as? Int
-        self.height = aDecoder.decodeObject(forKey: "height") as? Int
+        self.width = aDecoder.decodeObject(forKey: "width") as? Int ?? 0
+        self.height = aDecoder.decodeObject(forKey: "height") as? Int ?? 0
         self.frames = aDecoder.decodeObject(forKey: "frames") as? Int
         self.webPUrl = aDecoder.decodeObject(forKey: "webPUrl") as? String
         self.webPSize = aDecoder.decodeObject(forKey: "webPSize") as? Int
@@ -163,8 +163,8 @@ extension GPHImage: GPHMappable {
         obj.gifUrl = jsonData["url"] as? String
         obj.stillGifUrl = jsonData["still_url"]  as? String
         obj.gifSize = parseInt(jsonData["size"] as? String)
-        obj.width = parseInt(jsonData["width"] as? String)
-        obj.height = parseInt(jsonData["height"] as? String)
+        obj.width = parseInt(jsonData["width"] as? String) ?? 0
+        obj.height = parseInt(jsonData["height"] as? String) ?? 0
         obj.frames = parseInt(jsonData["frames"] as? String)
         obj.webPUrl = jsonData["webp"] as? String
         obj.webPSize = parseInt(jsonData["webp_size"] as? String)

--- a/Source/GPHMedia.swift
+++ b/Source/GPHMedia.swift
@@ -97,10 +97,6 @@ import Foundation
     public fileprivate(set) var isIndexable: Bool = false
     public fileprivate(set) var isSticker: Bool = false
     
-    /// Size of the original rendition.
-    public fileprivate(set) var originalRenditionWidth: Float? = 0.0
-    public fileprivate(set) var originalRenditionHeight: Float? = 0.0
-
     /// JSON Representation.
     public fileprivate(set) var jsonRepresentation: GPHJSONObject?
     
@@ -155,8 +151,6 @@ import Foundation
         self.isSticker = aDecoder.decodeBool(forKey: "isSticker")
         self.updateDate = aDecoder.decodeObject(forKey: "updateDate") as? Date
         self.createDate = aDecoder.decodeObject(forKey: "createDate") as? Date
-        self.originalRenditionWidth = aDecoder.decodeObject(forKey: "originalRenditionWidth") as? Float
-        self.originalRenditionHeight = aDecoder.decodeObject(forKey: "originalRenditionHeight") as? Float
         self.jsonRepresentation = aDecoder.decodeObject(forKey: "jsonRepresentation") as? GPHJSONObject
     }
     
@@ -192,8 +186,6 @@ import Foundation
         aCoder.encode(self.isSticker, forKey: "isSticker")
         aCoder.encode(self.updateDate, forKey: "updateDate")
         aCoder.encode(self.createDate, forKey: "createDate")
-        aCoder.encode(self.originalRenditionWidth, forKey: "originalRenditionWidth")
-        aCoder.encode(self.originalRenditionHeight, forKey: "originalRenditionHeight")
         aCoder.encode(self.jsonRepresentation, forKey: "jsonRepresentation")
     }
     
@@ -305,17 +297,6 @@ extension GPHMedia: GPHMappable {
                 let renditions = try GPHImages.mapData(obj, data: renditionData, request: requestType, media: mediaType)
                 obj.images = renditions
             }
-        }
-        
-        // Calculate original rendition size
-        
-        obj.originalRenditionWidth = nil
-        obj.originalRenditionHeight = nil
-        if let originalRendition = obj.images?.original,
-            let width = originalRendition.width,
-            let height = originalRendition.height {
-            obj.originalRenditionWidth = Float(width)
-            obj.originalRenditionHeight = Float(height)
         }
 
         return obj

--- a/Source/GPHMedia.swift
+++ b/Source/GPHMedia.swift
@@ -96,6 +96,10 @@ import Foundation
     public fileprivate(set) var isRealtime: Bool = false
     public fileprivate(set) var isIndexable: Bool = false
     public fileprivate(set) var isSticker: Bool = false
+    
+    /// Size of the original rendition.
+    public fileprivate(set) var originalRenditionWidth: Float? = 0.0
+    public fileprivate(set) var originalRenditionHeight: Float? = 0.0
 
     /// JSON Representation.
     public fileprivate(set) var jsonRepresentation: GPHJSONObject?
@@ -151,6 +155,8 @@ import Foundation
         self.isSticker = aDecoder.decodeBool(forKey: "isSticker")
         self.updateDate = aDecoder.decodeObject(forKey: "updateDate") as? Date
         self.createDate = aDecoder.decodeObject(forKey: "createDate") as? Date
+        self.originalRenditionWidth = aDecoder.decodeObject(forKey: "originalRenditionWidth") as? Float
+        self.originalRenditionHeight = aDecoder.decodeObject(forKey: "originalRenditionHeight") as? Float
         self.jsonRepresentation = aDecoder.decodeObject(forKey: "jsonRepresentation") as? GPHJSONObject
     }
     
@@ -186,6 +192,8 @@ import Foundation
         aCoder.encode(self.isSticker, forKey: "isSticker")
         aCoder.encode(self.updateDate, forKey: "updateDate")
         aCoder.encode(self.createDate, forKey: "createDate")
+        aCoder.encode(self.originalRenditionWidth, forKey: "originalRenditionWidth")
+        aCoder.encode(self.originalRenditionHeight, forKey: "originalRenditionHeight")
         aCoder.encode(self.jsonRepresentation, forKey: "jsonRepresentation")
     }
     
@@ -299,6 +307,17 @@ extension GPHMedia: GPHMappable {
             }
         }
         
+        // Calculate original rendition size
+        
+        obj.originalRenditionWidth = nil
+        obj.originalRenditionHeight = nil
+        if let originalRendition = obj.images?.original,
+            let width = originalRendition.width,
+            let height = originalRendition.height {
+            obj.originalRenditionWidth = Float(width)
+            obj.originalRenditionHeight = Float(height)
+        }
+
         return obj
     }
 


### PR DESCRIPTION
This PR exposes some properties in GPHImage to objective-C by making them non-optional (default value = 0). Swift optionals aren't bridged to Obj-C and by exposing these properties we can greatly speed up scrolling in the MAE by taking advantage of direct access to original rendition sizes without having to parse the GPHImage jsonRepresentation. 