### PR TITLE
Need to percent-encode plus signs in query params

### DIFF
--- a/Source/GPHAbstractClient.swift
+++ b/Source/GPHAbstractClient.swift
@@ -85,7 +85,7 @@ import Foundation
     /// Encode Strings for appending to URLs for endpoints like Term Suggestions/Categories
     ///
     /// - parameter string: String to be encoded.
-    /// - returns: A cancellable operation.
+    /// - returns: A percent encoded string.
     ///
     @objc
     func encodedStringForUrl(_ string: String) -> String {
@@ -96,7 +96,7 @@ import Foundation
         return encoded
     }
 
-    
+        
     /// Perform a request
     ///
     /// - parameter request: URLRequest


### PR DESCRIPTION
Swift's default .percentEncodedQuery does not encode + signs (see https://stackoverflow.com/a/37314144/43996). This makes it impossible to use, for example, a password or e-mail address that includes a + sign in it for auth. This PR uses our own custom encoding method that just removes + from the list of characters that shouldn't be percent-encoded when composing the request.