### PR TITLE
Add Swift Version in podspec

### DIFF
--- a/GiphyCoreSDK.podspec
+++ b/GiphyCoreSDK.podspec
@@ -12,6 +12,9 @@ Pod::Spec.new do |s|
     s.osx.deployment_target = '10.10'
     s.tvos.deployment_target = '9.0'
     s.watchos.deployment_target = '2.0'
+    s.pod_target_xcconfig = {
+        'SWIFT_VERSION' => '4.0'
+    }
 
     s.source_files = [
         'Source/*.swift',


### PR DESCRIPTION
Some issue found doing `pod install`:
> The “Swift Language Version” (SWIFT_VERSION) build setting must be set to a supported value for targets which use Swift. This setting can be set in the build settings editor.

Cocoapods has some problems configuring the SWIFT_VERSION and you have to add it in .podspec.
In your workspace, you can see this into the Pod project avoiding that error:
<img width="642" alt="captura de pantalla 2018-03-20 a las 21 33 08" src="https://user-images.githubusercontent.com/9945756/37681453-053826d6-2c87-11e8-8963-032979389adb.png">
 