### PR TITLE
User description is mapped to the wrong parameter

### DIFF
--- a/Sources/GPHUser.swift
+++ b/Sources/GPHUser.swift
@@ -219,7 +219,7 @@ extension GPHUser: GPHMappable {
         obj.suppressChrome = data["suppress_chrome"] as? Bool ?? false
         obj.name = data["name"] as? String
         obj.displayName = data["display_name"] as? String
-        obj.userDescription = data["user_description"] as? String
+        obj.userDescription = data["description"] as? String
         obj.attributionDisplayName = data["attribution_display_name"] as? String
         obj.twitter = data["twitter"] as? String
         obj.twitterUrl = data["twitter_url"] as? String

--- a/Tests/GiphyCoreSDK+XCTest.swift
+++ b/Tests/GiphyCoreSDK+XCTest.swift
@@ -243,7 +243,7 @@ extension XCTestCase {
                        "Display name won't match")
 
         XCTAssertEqual(obj.userDescription,
-                       obj.jsonRepresentation!["user_description"] as? String,
+                       obj.jsonRepresentation!["description"] as? String,
                        "User description won't match")
         
         XCTAssertEqual(obj.attributionDisplayName,


### PR DESCRIPTION
The `userDescription` parameter was mapped from `user_description` instead of `description`